### PR TITLE
Changed display property to flexbox from float.

### DIFF
--- a/code/photoblog.css
+++ b/code/photoblog.css
@@ -1,6 +1,8 @@
 .grid{
     width: 30%;
-    float:left;
+    //float:left;
+    display: flex;
+    flex-direction: column;
     margin: 1.66%;
 }
 


### PR DESCRIPTION
Using float for display is as good as deprecated because it severely affects the responsiveness. The reason that using the float method is not suited for the layout of your page is that the float CSS property was originally intended only to have text wrap around an image (magazine style) and is, by design, not best suited for general page layout purposes. When changing floated elements later, sometimes you will have positioning issues because they are not in the page flow.